### PR TITLE
Allow java.util.Map.size()

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -136,6 +136,7 @@ method java.util.Map putAll java.util.Map
 method java.util.Map values
 method java.util.Map$Entry getKey
 method java.util.Map$Entry getValue
+method java.util.Map size
 staticMethod java.util.TimeZone getTimeZone java.lang.String
 staticMethod java.util.UUID randomUUID
 method java.util.concurrent.Callable call


### PR DESCRIPTION
I see that `java.util.Collection.size()` is whitelisted, so presumably it would also be OK to whitelist `java.util.Map.size()`?

Motivation is to enable check for empty Map...

Calling `java.util.Map.size()` does _not_ make it appear in the script approvals, so I did not find a workaround...

I guess the more groovy way is to just do `if (mymap)` instead of `if (mymap.size()>0)` - but getting the number of items in a map seems like a valid thing to do...

Or am I missing something obvious here?`
